### PR TITLE
Ignore directories

### DIFF
--- a/gorganizer.go
+++ b/gorganizer.go
@@ -61,6 +61,9 @@ func main() {
 	fmt.Println("GOrganizing your Files")
 
 	for _, f := range files {
+		if f.IsDir() {
+			continue
+		}
 
 		file := filepath.Join(*inputFolder, f.Name())
 		ext := strings.TrimPrefix(path.Ext(file), ".")


### PR DESCRIPTION
Theoretically you could have directories with extensions, but I doubt that's the intended use case.

Instead, simply ignore directories and look only at files in one folder.