### PR TITLE
Fix check for missing language code

### DIFF
--- a/defaultdb.go
+++ b/defaultdb.go
@@ -22,8 +22,7 @@ func testDb(file string) bool {
 
 func initDb() {
 
-	if language != "en" && language != "tr" {
-
+	if language == "" {
 		language = "en"
 	}
 


### PR DESCRIPTION
Previously any languages besides 'en' and 'tr' would have been overridden with 'en'.
Instead, assume 'en' only when it's empty.

Otherwise it would be impossible to create a file for your own language, because it would force you use to 'en'.